### PR TITLE
feat: add log diff engine, view, and worker for comparing CallTrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,26 @@
 - **One-click analysis**: imported logs open the full analysis modal (Summary, Calls, Analysis, Raw)
 
 ### 🌳 Advanced Visualization
-- **4 complementary views**:
+- **5 complementary views**:
   - **Summary**: Overview with statistics and metadata
   - **Calls**: Hierarchical call tree with performance analysis (built via Web Worker)
   - **Analysis**: Anti-pattern detection with severity and suggestions
   - **Raw Log**: Original log content with copy/export options
+  - **Diff**: [NEW] Side-by-side comparison of two logs to identify execution divergences
 - **Top 5 Slowest Nodes**: Instantly identify performance bottlenecks
 - **Log navigation**: Previous/Next buttons to switch between logs without closing the modal
 - **Advanced filtering**: errors only, search in tree
 - **Export reports**: Export call tree and performance data in `.txt` or `.md` format
+
+### 🔀 Log Diffing [NEW]
+- **Side-by-side comparison** of two call trees to spot execution divergences
+- **LCS-based alignment** matching nodes by signature across different logs
+- **Color-coded differences**: added (green), removed (red), changed (orange), match (grey)
+- **Divergence navigation**: Prev/Next buttons to jump between differences
+- **Import directly from Diff tab**: import a `.txt` or `.log` file without leaving the modal
+- **Select from existing imports**: dropdown lists all previously imported logs
+- **Auto-sync with Files tab**: imports from the Diff tab appear in the panel's Files history
+- **Web Worker powered**: diff computation runs off the main thread with a 10s timeout
 
 ### ⚡ Performance
 - **Smart caching** to avoid redundant requests
@@ -84,7 +95,8 @@
 7. Click "Details" to analyze a log in depth
 8. Explore the different tabs: Summary, Calls, Analysis, Raw Log
 9. Use the **Analysis tab** to detect anti-patterns and export reports (PDF/MD/TXT)
-10. Use the export button in the Calls tab to generate a performance report
+10. Use the **Diff tab** to compare execution with an imported log from another environment
+11. Use the export button in the Calls tab to generate a performance report
 
 ## 🧪 Testing
 
@@ -100,7 +112,7 @@ Contributions are welcome!
 
 ## ℹ️ About
 
-By Claude Sonnet 4.5 and occasionally Maxime Clavel
+By Claude Opus 4.6 and occasionally Maxime Clavel
 Contact : FoxLog.Extension@proton.me
 
 ## 📄 License

--- a/docs/tech-solution/log-diffing.md
+++ b/docs/tech-solution/log-diffing.md
@@ -1,0 +1,333 @@
+# Comparateur de Logs (Log Diffing)
+
+## Objectif
+
+Permettre de comparer côte à côte deux logs Salesforce pour identifier rapidement les divergences d'exécution entre deux environnements, deux profils ou deux tentatives.
+
+## Vue d'ensemble
+
+Le diffing s'appuie sur les **CallTree** déjà construits par `CallTreeBuilderService`. On compare deux arbres nœud par nœud (par signature `type + name`) pour détecter les divergences : nœuds manquants, écarts de durée, erreurs dans un seul arbre, requêtes SOQL/DML supplémentaires.
+
+```text
+CallTree A (env/profil A)     CallTree B (env/profil B)
+         │                              │
+         └──────── DiffEngine ──────────┘
+                       │
+                  DiffResult[]
+                       │
+                  DiffView (split-pane UI)
+```
+
+## Fichiers à créer
+
+| Fichier | Rôle |
+|---------|------|
+| `src/services/log-diff-engine.js` | Algorithme de diff entre 2 CallTree |
+| `src/workers/log-diff-worker.js` | Web Worker pour le diff (logs volumineux) |
+| `src/ui/log-diff-view.js` | Vue côte à côte avec surlignage |
+
+## Fichiers à modifier
+
+| Fichier | Modification |
+|---------|-------------|
+| `src/ui/modal-manager.js` | Ajout du 5ᵉ onglet "Diff" + wiring |
+| `src/modal-styles.css` | Styles du layout split-pane |
+| `src/core/constants.js` | Clés i18n + seuils de config |
+| `manifest.json` | Ajout de `log-diff-engine.js`, `log-diff-worker.js`, `log-diff-view.js` |
+
+## Structures de données
+
+### DiffResult
+
+```javascript
+{
+  summary: {
+    totalDivergences: number,
+    onlyInA: number,
+    onlyInB: number,
+    timingDiffs: number,
+    errorDiffs: number
+  },
+  pairs: DiffPair[]
+}
+```
+
+### DiffPair
+
+```javascript
+{
+  nodeA: CallTreeNode | null,
+  nodeB: CallTreeNode | null,
+  status: 'match' | 'added' | 'removed' | 'changed',
+  changes: {
+    duration: { a: number, b: number, delta: number } | null,
+    hasError: { a: boolean, b: boolean } | null,
+    soqlCount: { a: number, b: number } | null,
+    dmlCount: { a: number, b: number } | null
+  },
+  children: DiffPair[]
+}
+```
+
+## Algorithme de diff
+
+### Signature de nœud
+
+Chaque nœud est identifié par une signature composée de `type:class.method` (et non par son `id` interne qui diffère entre logs). Les doublons (même méthode appelée N fois) sont distingués par leur position ordinale parmi les frères de même signature.
+
+### Alignement LCS
+
+L'alignement des enfants entre deux nœuds parents utilise l'algorithme **Longest Common Subsequence** sur les séquences de signatures.
+
+```text
+function alignChildren(childrenA, childrenB):
+    1. Créer les signatures : "METHOD:MyClass.myMethod"
+    2. Calculer la LCS des deux séquences de signatures
+    3. Parcourir les deux listes en parallèle :
+       - Éléments dans la LCS → paire match/changed
+       - Éléments hors LCS côté A → removed
+       - Éléments hors LCS côté B → added
+    4. Pour chaque paire matched, récurser sur les enfants
+```
+
+### Classification des paires
+
+| Status | Condition |
+|--------|-----------|
+| `match` | Même signature, pas de changement significatif |
+| `changed` | Même signature, écart de durée > seuil OU différence d'erreur |
+| `added` | Nœud présent dans B uniquement |
+| `removed` | Nœud présent dans A uniquement |
+
+### Seuil de sensibilité
+
+Par défaut, un écart de durée est considéré significatif quand il dépasse **50 ms** ET **200 %** de la durée de référence. Ces seuils sont configurables via `CONFIG.DIFF_THRESHOLD_MS` et `CONFIG.DIFF_THRESHOLD_PERCENT`.
+
+## Architecture des fichiers
+
+### `src/services/log-diff-engine.js`
+
+```javascript
+(function() {
+  'use strict';
+  window.FoxLog = window.FoxLog || {};
+  const logger = window.FoxLog.logger || console;
+
+  class LogDiffEngine {
+    /**
+     * Compare deux CallTree et retourne le résultat du diff
+     * @param {Object} treeA - CallTree gauche
+     * @param {Object} treeB - CallTree droite
+     * @param {Object} options - Configuration du diff
+     * @param {number} options.thresholdMs - Seuil absolu en ms
+     * @param {number} options.thresholdPercent - Seuil relatif en %
+     * @param {boolean} options.ignoreSystem - Ignorer les nœuds système
+     * @returns {DiffResult}
+     */
+    diff(treeA, treeB, options = {}) { /* ... */ }
+
+    _alignChildren(childrenA, childrenB) { /* LCS */ }
+    _computeLCS(seqA, seqB) { /* ... */ }
+    _getSignature(node) { /* ... */ }
+    _classifyPair(nodeA, nodeB, options) { /* ... */ }
+  }
+
+  window.FoxLog.logDiffEngine = new LogDiffEngine();
+})();
+```
+
+### `src/workers/log-diff-worker.js`
+
+Le Worker reçoit les deux arbres sérialisés et exécute le diff hors du thread principal.
+
+```text
+Main thread                    Worker
+     │                            │
+     ├─ postMessage({             │
+     │    type: 'diff',           │
+     │    treeA, treeB, options   │
+     │  }) ───────────────────────►
+     │                            ├─ LCS + récursion
+     │                            │
+     │  ◄─────────────────────────┤ postMessage({ type: 'result', diff })
+     │                            │
+```
+
+Le code du `LogDiffEngine` est dupliqué dans le worker (pas d'import possible en Manifest V3 sans module worker). Alternativement, utiliser un worker de type `module` si le navigateur cible le supporte.
+
+### `src/ui/log-diff-view.js`
+
+```javascript
+(function() {
+  'use strict';
+  window.FoxLog = window.FoxLog || {};
+  const logger = window.FoxLog.logger || console;
+
+  class LogDiffView {
+    /**
+     * @param {HTMLElement} container - Conteneur DOM
+     * @param {DiffResult} diffResult - Résultat du diff
+     * @param {Object} metaA - Métadonnées du log A
+     * @param {Object} metaB - Métadonnées du log B
+     */
+    constructor(container, diffResult, metaA, metaB) { /* ... */ }
+
+    render() { /* ... */ }
+    _renderSplitPane() { /* ... */ }
+    _renderDiffPair(pair, depth) { /* ... */ }
+    _syncScroll() { /* ... */ }
+    navigateNext() { /* ... */ }
+    navigatePrev() { /* ... */ }
+    destroy() { /* ... */ }
+  }
+
+  window.FoxLog.LogDiffView = LogDiffView;
+})();
+```
+
+## Interface utilisateur
+
+### Source des logs
+
+- **Log A (gauche)** : le log actuellement ouvert dans la modale. Non modifiable depuis l'onglet Diff — c'est toujours le log que l'utilisateur a cliqué dans la liste Salesforce ou dans l'onglet Files.
+- **Log B (droite)** : sélectionné via un dropdown parmi les **logs importés**, ou importé directement depuis l'onglet Diff via le bouton "📂 Importer un fichier". Un fichier importé depuis l'onglet Diff est automatiquement ajouté à l'historique d'import (onglet Files du panel) et le diff se lance immédiatement.
+
+### Points d'entrée
+
+Trois façons d'accéder au diff :
+
+1. **Depuis la modale (sélection)** : l'utilisateur ouvre un log, va sur l'onglet Diff, et sélectionne un log déjà importé comme Log B via le dropdown.
+2. **Depuis la modale (import direct)** : dans l'onglet Diff, il clique sur "📂 Importer un fichier", sélectionne un `.txt` ou `.log`. Le fichier est sauvé dans le storage, ajouté au dropdown, et le diff se lance automatiquement.
+3. **Depuis l'onglet Files du panel** : cliquer sur un log importé ouvre la modale. L'utilisateur accède ensuite au diff via l'onglet Diff.
+
+### Layout
+
+```text
+┌─────────────────────────────────────────────────────┐
+│  [Log B ▼ imported logs]  ou  [📂 Importer un fichier] │
+├──────────────────────────┬──────────────────────────┤
+│  Log A (current)         │  Log B (importé)        │
+│  ■ MyClass.execute       │  ■ MyClass.execute       │
+│    120ms                 │    3400ms  ⚠️ +2837%     │
+│  ├ doQuery  2ms          │  ├ doQuery  2ms          │
+│  ├ validate 5ms          │  ├ validate 5ms          │
+│                          │  ├ extraCall 3200ms  🆕  │
+│  ├ commit   3ms          │  ├ commit   3ms          │
+│  └ cleanup  1ms          │  └ ❌ cleanup EXCEPTION  │
+├──────────────────────────┴──────────────────────────┤
+│  ◄ Prev diff  │  3/7 divergences  │  Next diff ►    │
+└─────────────────────────────────────────────────────┘
+```
+
+### Code couleur
+
+| Couleur | Signification |
+|---------|--------------|
+| Gris (par défaut) | Nœuds identiques (`match`) |
+| Rouge | Nœud supprimé ou en erreur (`removed`) |
+| Bleu | Nœud ajouté (`added`) |
+| Orange | Écart de performance significatif (`changed`) |
+
+### Fonctionnalités
+
+- **Scroll synchronisé** : les deux panneaux scrollent ensemble via un listener `onscroll`
+- **Navigation entre divergences** : boutons Prev/Next pour sauter directement au diff suivant
+- **Virtualisation** : seuls les nœuds visibles sont rendus (même pattern que `CallTreeView`)
+- **Sélecteur Log B** : un dropdown alimenté par la liste des logs importés (`chrome.storage.local` clé `importedLogs`)
+- **Import direct** : bouton "📂 Importer un fichier" à côté du dropdown, qui sauvegarde dans le storage, met à jour le dropdown, rafraîchit l'onglet Files du panel, et lance le diff immédiatement
+- **Résumé** : bandeau en bas avec le nombre total de divergences par catégorie
+
+### Intégration dans la modale
+
+Ajout d'un 5ᵉ onglet dans la barre de tabs existante :
+
+```text
+ Summary | Analysis | Calls | Raw Log | Diff
+```
+
+L'onglet Diff est toujours visible. Le contenu est chargé en lazy (comme l'onglet Calls). Log A est toujours le log courant de la modale (non modifiable). Si aucun log importé n'existe, l'utilisateur peut importer directement depuis l'onglet Diff.
+
+### Synchronisation avec l'onglet Files du panel
+
+Lorsqu'un fichier est importé depuis l'onglet Diff, un événement `foxlog:importListChanged` est dispatché. Le `PanelManager` écoute cet événement et rafraîchit automatiquement la liste d'historique d'import.
+
+## Flux utilisateur
+
+### Scénario principal : comparaison cross-environnement
+
+1. L'utilisateur ouvre un log depuis l'onglet **Salesforce** → la modale s'ouvre (Log A)
+2. Il va sur l'onglet **Diff** de la modale
+3. Il clique sur **📂 Importer un fichier** et sélectionne le log de l'autre environnement
+4. Le fichier est sauvé dans le storage (visible aussi dans l'onglet Files)
+5. Le `LogDiffEngine` compare les deux CallTrees via le Worker
+6. La `LogDiffView` affiche le résultat côte à côte
+7. Il navigue entre les divergences avec les boutons Prev/Next
+
+### Scénario avec log déjà importé
+
+1. L'utilisateur ouvre un log (Salesforce ou importé)
+2. Il va sur l'onglet **Diff**
+3. Le dropdown liste les logs importés existants
+4. Il sélectionne un log comme Log B
+5. Le diff se lance
+
+## Considérations techniques
+
+### Performance
+
+- **LCS** a une complexité O(n × m) où n et m sont le nombre d'enfants à aligner. Pour les arbres > 5000 nœuds, le Worker est indispensable.
+- Prévoir un timeout de 10 s avec message utilisateur si le diff est trop long.
+- Libérer le `DiffResult` de la mémoire à la fermeture de l'onglet Diff.
+
+### Mémoire
+
+Deux CallTrees + un DiffResult en mémoire simultanément. Prévoir un `destroy()` agressif sur la `LogDiffView` qui nullifie les références et appelle `clearCache()` sur le builder si nécessaire.
+
+### Manifest V3
+
+- Pas de `eval()` dans le worker
+- Le worker doit être déclaré dans `manifest.json` sous `web_accessible_resources` si chargé dynamiquement
+- Tout le code doit être statique (pas de construction de fonction à la volée)
+
+### Accessibilité
+
+- Les divergences doivent avoir un `aria-label` descriptif (ex: "Nœud ajouté : extraCall, durée 3200ms")
+- La navigation Prev/Next doit être accessible au clavier
+- Les couleurs ne doivent pas être le seul indicateur : ajouter des icônes (🆕, ❌, ⚠️)
+
+## Configuration (constants.js)
+
+```javascript
+window.FoxLog.CONFIG.DIFF_THRESHOLD_MS = 50;
+window.FoxLog.CONFIG.DIFF_THRESHOLD_PERCENT = 200;
+window.FoxLog.CONFIG.DIFF_IGNORE_SYSTEM = true;
+window.FoxLog.CONFIG.DIFF_WORKER_TIMEOUT = 10000;
+```
+
+## Clés i18n à ajouter
+
+```javascript
+window.FoxLog.i18n.diffTab = 'Diff';
+window.FoxLog.i18n.diffSelectLog = 'Select an imported log to compare';
+window.FoxLog.i18n.diffNoImports = 'Import a log first (Files tab)';
+window.FoxLog.i18n.diffAdded = 'Added';
+window.FoxLog.i18n.diffRemoved = 'Removed';
+window.FoxLog.i18n.diffChanged = 'Changed';
+window.FoxLog.i18n.diffMatch = 'Identical';
+window.FoxLog.i18n.diffSummary = '{0} divergences found';
+window.FoxLog.i18n.diffPrev = 'Previous difference';
+window.FoxLog.i18n.diffNext = 'Next difference';
+window.FoxLog.i18n.diffComputing = 'Computing diff...';
+window.FoxLog.i18n.diffTimeout = 'Diff computation timed out';
+```
+
+## Ordre d'implémentation recommandé
+
+1. `src/services/log-diff-engine.js` — cœur algorithmique, testable unitairement
+2. `tests/test-diff-engine.js` — tests sur des arbres simples
+3. `src/workers/log-diff-worker.js` — parallélisation
+4. `src/ui/log-diff-view.js` — rendu visuel
+5. Modifications de `modal-manager.js` — intégration onglet
+6. Modifications de `modal-styles.css` — styles split-pane
+7. Modifications de `constants.js` — config + i18n
+8. Mise à jour de `manifest.json` — déclaration des nouveaux fichiers

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "FoxLog - Salesforce Debug Log Viewer",
-  "version": "1.4.1",
+  "version": "1.5.1",
   "description": "Display Salesforce debug logs in a user-friendly format with error detection, anti-pattern analysis, and debug control.",
   
   "permissions": [
@@ -45,9 +45,11 @@
         "src/services/log-preview-service.js",
         "src/services/call-tree-builder.js",
         "src/services/anti-pattern-detector.js",
+        "src/services/log-diff-engine.js",
         "src/parsers/log-parser.js",
         "src/ui/filter-manager.js",
         "src/ui/call-tree-view.js",
+        "src/ui/log-diff-view.js",
         "src/ui/modal-manager.js",
         "src/ui/panel-manager.js",
         "src/content.js"
@@ -67,6 +69,7 @@
       "resources": [
         "src/assets/*.png",
         "src/workers/call-tree-worker.js",
+        "src/workers/log-diff-worker.js",
         "src/injected.js"
       ],
       "matches": [

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -44,7 +44,13 @@
     ENABLE_SUCCESS_LOGS: true,  // Show success messages (✅)
     ENABLE_INFO_LOGS: true,     // Show info messages
     ENABLE_WARN_LOGS: true,     // Show warnings (⚠️)
-    ENABLE_ERROR_LOGS: true     // Show errors (❌) - always recommended
+    ENABLE_ERROR_LOGS: true,    // Show errors (❌) - always recommended
+    
+    // Diff thresholds
+    DIFF_THRESHOLD_MS: 50,
+    DIFF_THRESHOLD_PERCENT: 200,
+    DIFF_IGNORE_SYSTEM: true,
+    DIFF_WORKER_TIMEOUT: 10000
   };
   
   // ============================================
@@ -300,6 +306,24 @@
     importFileTooLarge: isFrench ? 'Fichier trop volumineux (max 5 MB)' : 'File too large (max 5 MB)',
     importInvalidType: isFrench ? 'Type de fichier invalide. Utilisez .txt ou .log' : 'Invalid file type. Use .txt or .log',
     importSuccess: isFrench ? 'Log importé avec succès !' : 'Log imported successfully!',
-    importError: isFrench ? 'Erreur lors de l\'import' : 'Import error'
+    importError: isFrench ? 'Erreur lors de l\'import' : 'Import error',
+    
+    // Diff tab
+    diffTab: 'Diff',
+    diffSelectLog: isFrench ? 'Sélectionner un log importé à comparer' : 'Select an imported log to compare',
+    diffNoImports: isFrench ? 'Importez un log d\'abord (onglet Fichiers)' : 'Import a log first (Files tab)',
+    diffImportFile: isFrench ? 'Importer un fichier' : 'Import a file',
+    diffOr: isFrench ? 'ou' : 'or',
+    diffAdded: isFrench ? 'Ajouté' : 'Added',
+    diffRemoved: isFrench ? 'Supprimé' : 'Removed',
+    diffChanged: isFrench ? 'Modifié' : 'Changed',
+    diffMatch: isFrench ? 'Identique' : 'Identical',
+    diffDivergences: isFrench ? 'divergences' : 'divergences',
+    diffNoDivergences: isFrench ? 'Aucune divergence' : 'No divergences',
+    diffPrev: isFrench ? 'Préc.' : 'Prev',
+    diffNext: isFrench ? 'Suiv.' : 'Next',
+    diffComputing: isFrench ? 'Calcul du diff...' : 'Computing diff...',
+    diffTimeout: isFrench ? 'Le calcul du diff a expiré' : 'Diff computation timed out',
+    diffError: isFrench ? 'Erreur lors du calcul du diff' : 'Diff computation error'
   };
 })();

--- a/src/modal-styles.css
+++ b/src/modal-styles.css
@@ -2827,3 +2827,359 @@
     background: #0176d3;
   }
 }
+
+/* ============================================
+   DIFF VIEW STYLES
+   ============================================ */
+
+.sf-diff-select-container {
+  display: flex !important;
+  flex-direction: column !important;
+  height: 100% !important;
+  gap: 12px !important;
+}
+
+.sf-diff-top-bar {
+  display: flex !important;
+  align-items: center !important;
+  gap: 12px !important;
+  flex-wrap: wrap !important;
+}
+
+.sf-diff-or {
+  color: #9ca3af !important;
+  font-size: 13px !important;
+  font-style: italic !important;
+}
+
+.sf-diff-import-btn {
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 6px !important;
+  padding: 8px 16px !important;
+  border: 1px dashed #d1d5db !important;
+  border-radius: 8px !important;
+  background: #f9fafb !important;
+  color: #374151 !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  cursor: pointer !important;
+  transition: all 0.15s ease !important;
+  white-space: nowrap !important;
+}
+
+.sf-diff-import-btn:hover,
+.sf-diff-import-btn:focus-visible {
+  border-color: #0176d3 !important;
+  background: #eff6ff !important;
+  color: #0176d3 !important;
+  outline: none !important;
+}
+
+.sf-diff-log-select {
+  flex: 1 !important;
+  min-width: 200px !important;
+  max-width: 500px !important;
+  padding: 8px 12px !important;
+  border: 1px solid #d1d5db !important;
+  border-radius: 8px !important;
+  font-size: 14px !important;
+  color: #1f2937 !important;
+  background: #fff !important;
+  cursor: pointer !important;
+}
+
+.sf-diff-log-select:focus {
+  outline: none !important;
+  border-color: #0176d3 !important;
+  box-shadow: 0 0 0 3px rgba(1, 118, 211, 0.1) !important;
+}
+
+.sf-diff-content-area {
+  flex: 1 !important;
+  min-height: 0 !important;
+  overflow: hidden !important;
+}
+
+.sf-diff-view-container {
+  height: 100% !important;
+  display: flex !important;
+  flex-direction: column !important;
+}
+
+/* Diff wrapper */
+.sf-diff-wrapper {
+  display: flex !important;
+  flex-direction: column !important;
+  height: 100% !important;
+  border: 1px solid #e5e7eb !important;
+  border-radius: 8px !important;
+  overflow: hidden !important;
+}
+
+/* Header with filenames */
+.sf-diff-header {
+  display: flex !important;
+  background: #f3f4f6 !important;
+  border-bottom: 1px solid #e5e7eb !important;
+}
+
+.sf-diff-meta {
+  flex: 1 !important;
+  display: flex !important;
+  align-items: center !important;
+  gap: 8px !important;
+  padding: 8px 12px !important;
+  min-width: 0 !important;
+}
+
+.sf-diff-meta-a {
+  border-right: 1px solid #e5e7eb !important;
+}
+
+.sf-diff-label {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 22px !important;
+  height: 22px !important;
+  border-radius: 50% !important;
+  font-size: 11px !important;
+  font-weight: 700 !important;
+  color: #fff !important;
+  flex-shrink: 0 !important;
+}
+
+.sf-diff-meta-a .sf-diff-label {
+  background: #6366f1 !important;
+}
+
+.sf-diff-meta-b .sf-diff-label {
+  background: #0ea5e9 !important;
+}
+
+.sf-diff-filename {
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  color: #374151 !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+}
+
+/* Summary bar */
+.sf-diff-summary-bar {
+  display: flex !important;
+  align-items: center !important;
+  gap: 12px !important;
+  padding: 6px 12px !important;
+  background: #fafafa !important;
+  border-bottom: 1px solid #e5e7eb !important;
+  flex-wrap: wrap !important;
+}
+
+.sf-diff-stat {
+  font-size: 12px !important;
+  font-weight: 600 !important;
+  padding: 2px 8px !important;
+  border-radius: 10px !important;
+}
+
+.sf-diff-stat-total {
+  color: #374151 !important;
+  background: #e5e7eb !important;
+}
+
+.sf-diff-stat-removed {
+  color: #dc2626 !important;
+  background: #fef2f2 !important;
+}
+
+.sf-diff-stat-added {
+  color: #16a34a !important;
+  background: #dcfce7 !important;
+}
+
+.sf-diff-stat-timing {
+  color: #d97706 !important;
+  background: #fffbeb !important;
+}
+
+.sf-diff-stat-error {
+  color: #dc2626 !important;
+  background: #fef2f2 !important;
+}
+
+/* Split panes */
+.sf-diff-panes {
+  display: flex !important;
+  flex: 1 !important;
+  min-height: 0 !important;
+  overflow: hidden !important;
+}
+
+.sf-diff-pane {
+  flex: 1 !important;
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
+  min-width: 0 !important;
+}
+
+.sf-diff-pane-a {
+  border-right: none !important;
+}
+
+.sf-diff-gutter {
+  width: 3px !important;
+  background: #d1d5db !important;
+  flex-shrink: 0 !important;
+}
+
+/* Diff rows */
+.sf-diff-row {
+  display: flex !important;
+  align-items: center !important;
+  gap: 6px !important;
+  min-height: 32px !important;
+  font-size: 13px !important;
+  font-family: 'SF Mono', 'Fira Code', monospace !important;
+  border-bottom: 1px solid #f3f4f6 !important;
+  transition: background 0.15s ease !important;
+}
+
+.sf-diff-row:hover {
+  background: rgba(0, 0, 0, 0.02) !important;
+}
+
+.sf-diff-row-match {
+  color: #374151 !important;
+}
+
+.sf-diff-row-added {
+  background: #dcfce7 !important;
+}
+
+.sf-diff-row-removed {
+  background: #fef2f2 !important;
+}
+
+.sf-diff-row-changed {
+  background: #fffbeb !important;
+}
+
+.sf-diff-row-empty {
+  background: #f9fafb !important;
+  opacity: 0.5 !important;
+}
+
+.sf-diff-row-highlight {
+  outline: 2px solid #0176d3 !important;
+  outline-offset: -2px !important;
+  animation: diff-highlight-pulse 0.5s ease !important;
+}
+
+@keyframes diff-highlight-pulse {
+  0% { outline-color: transparent; }
+  50% { outline-color: #0176d3; }
+  100% { outline-color: #0176d3; }
+}
+
+/* Row elements */
+.sf-diff-node-icon {
+  flex-shrink: 0 !important;
+  width: 20px !important;
+  text-align: center !important;
+}
+
+.sf-diff-node-name {
+  flex: 1 !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+  min-width: 0 !important;
+}
+
+.sf-diff-node-duration {
+  flex-shrink: 0 !important;
+  font-size: 11px !important;
+  color: #6b7280 !important;
+  min-width: 50px !important;
+  text-align: right !important;
+}
+
+/* Badges */
+.sf-diff-badge {
+  flex-shrink: 0 !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  font-size: 10px !important;
+  font-weight: 700 !important;
+  padding: 1px 6px !important;
+  border-radius: 8px !important;
+}
+
+.sf-diff-badge-added {
+  background: #16a34a !important;
+  color: #fff !important;
+}
+
+.sf-diff-badge-removed {
+  background: #dc2626 !important;
+  color: #fff !important;
+}
+
+.sf-diff-badge-timing {
+  background: #f59e0b !important;
+  color: #fff !important;
+}
+
+.sf-diff-error-icon {
+  flex-shrink: 0 !important;
+}
+
+.sf-diff-empty-placeholder {
+  display: block !important;
+  min-height: 32px !important;
+}
+
+/* Navigation bar */
+.sf-diff-nav-bar {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 16px !important;
+  padding: 8px 12px !important;
+  background: #f9fafb !important;
+  border-top: 1px solid #e5e7eb !important;
+}
+
+.sf-diff-nav-btn {
+  padding: 4px 14px !important;
+  border: 1px solid #d1d5db !important;
+  border-radius: 6px !important;
+  background: #fff !important;
+  color: #374151 !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  cursor: pointer !important;
+  transition: all 0.15s ease !important;
+}
+
+.sf-diff-nav-btn:hover {
+  background: #0176d3 !important;
+  color: #fff !important;
+  border-color: #0176d3 !important;
+}
+
+.sf-diff-nav-position {
+  font-size: 13px !important;
+  color: #6b7280 !important;
+  font-weight: 500 !important;
+}
+
+.sf-diff-nav-current {
+  font-weight: 700 !important;
+  color: #0176d3 !important;
+}
+}

--- a/src/services/log-diff-engine.js
+++ b/src/services/log-diff-engine.js
@@ -1,0 +1,311 @@
+// src/services/log-diff-engine.js
+// Diff engine to compare two CallTree structures and detect divergences
+
+(function() {
+  'use strict';
+
+  window.FoxLog = window.FoxLog || {};
+  const logger = window.FoxLog.logger || console;
+
+  class LogDiffEngine {
+    /**
+     * Compare two CallTrees and return a structured diff result
+     * @param {Object} treeA - CallTree (left / reference)
+     * @param {Object} treeB - CallTree (right / comparison)
+     * @param {Object} [options] - Diff configuration
+     * @param {number} [options.thresholdMs=50] - Minimum absolute duration delta to flag
+     * @param {number} [options.thresholdPercent=200] - Minimum relative delta (%) to flag
+     * @param {boolean} [options.ignoreSystem=true] - Skip system-level nodes
+     * @returns {Object} DiffResult with summary and pairs tree
+     */
+    diff(treeA, treeB, options = {}) {
+      const config = {
+        thresholdMs: options.thresholdMs ?? window.FoxLog.CONFIG?.DIFF_THRESHOLD_MS ?? 50,
+        thresholdPercent: options.thresholdPercent ?? window.FoxLog.CONFIG?.DIFF_THRESHOLD_PERCENT ?? 200,
+        ignoreSystem: options.ignoreSystem ?? window.FoxLog.CONFIG?.DIFF_IGNORE_SYSTEM ?? true
+      };
+
+      const rootA = treeA?.root;
+      const rootB = treeB?.root;
+
+      if (!rootA || !rootB) {
+        return this._emptyResult();
+      }
+
+      const rootPair = this._diffNode(rootA, rootB, config);
+
+      const summary = this._buildSummary(rootPair);
+
+      return { summary, pairs: rootPair };
+    }
+
+    /**
+     * @param {Object} nodeA
+     * @param {Object} nodeB
+     * @param {Object} config
+     * @returns {Object} DiffPair
+     */
+    _diffNode(nodeA, nodeB, config) {
+      const changes = this._detectChanges(nodeA, nodeB, config);
+      const hasChanges = changes.duration || changes.hasError || changes.soqlCount || changes.dmlCount;
+      const status = hasChanges ? 'changed' : 'match';
+
+      const childrenA = this._filterChildren(nodeA.children || [], config);
+      const childrenB = this._filterChildren(nodeB.children || [], config);
+
+      const childPairs = this._alignChildren(childrenA, childrenB, config);
+
+      return {
+        nodeA: this._slimNode(nodeA),
+        nodeB: this._slimNode(nodeB),
+        status,
+        changes,
+        children: childPairs
+      };
+    }
+
+    /**
+     * Align children of two nodes using LCS on signatures
+     * @param {Array} childrenA
+     * @param {Array} childrenB
+     * @param {Object} config
+     * @returns {Array<Object>} Array of DiffPair
+     */
+    _alignChildren(childrenA, childrenB, config) {
+      const sigsA = childrenA.map(n => this._getSignature(n));
+      const sigsB = childrenB.map(n => this._getSignature(n));
+
+      const lcs = this._computeLCS(sigsA, sigsB);
+
+      const pairs = [];
+      let idxA = 0;
+      let idxB = 0;
+
+      for (const match of lcs) {
+        while (idxA < match.idxA) {
+          pairs.push(this._makeRemovedPair(childrenA[idxA]));
+          idxA++;
+        }
+        while (idxB < match.idxB) {
+          pairs.push(this._makeAddedPair(childrenB[idxB]));
+          idxB++;
+        }
+        pairs.push(this._diffNode(childrenA[idxA], childrenB[idxB], config));
+        idxA++;
+        idxB++;
+      }
+
+      while (idxA < childrenA.length) {
+        pairs.push(this._makeRemovedPair(childrenA[idxA]));
+        idxA++;
+      }
+      while (idxB < childrenB.length) {
+        pairs.push(this._makeAddedPair(childrenB[idxB]));
+        idxB++;
+      }
+
+      return pairs;
+    }
+
+    /**
+     * LCS returning index pairs for matched elements
+     * @param {string[]} seqA
+     * @param {string[]} seqB
+     * @returns {Array<{idxA: number, idxB: number}>}
+     */
+    _computeLCS(seqA, seqB) {
+      const m = seqA.length;
+      const n = seqB.length;
+
+      // DP table
+      const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+
+      for (let i = 1; i <= m; i++) {
+        for (let j = 1; j <= n; j++) {
+          if (seqA[i - 1] === seqB[j - 1]) {
+            dp[i][j] = dp[i - 1][j - 1] + 1;
+          } else {
+            dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+          }
+        }
+      }
+
+      // Backtrack to find matched indices
+      const result = [];
+      let i = m;
+      let j = n;
+      while (i > 0 && j > 0) {
+        if (seqA[i - 1] === seqB[j - 1]) {
+          result.push({ idxA: i - 1, idxB: j - 1 });
+          i--;
+          j--;
+        } else if (dp[i - 1][j] > dp[i][j - 1]) {
+          i--;
+        } else {
+          j--;
+        }
+      }
+
+      result.reverse();
+      return result;
+    }
+
+    /**
+     * Build a signature for a node: "TYPE:name"
+     * @param {Object} node
+     * @returns {string}
+     */
+    _getSignature(node) {
+      return `${node.type || 'UNKNOWN'}:${node.name || ''}`;
+    }
+
+    /**
+     * Detect meaningful changes between two matched nodes
+     * @param {Object} nodeA
+     * @param {Object} nodeB
+     * @param {Object} config
+     * @returns {Object}
+     */
+    _detectChanges(nodeA, nodeB, config) {
+      const changes = {
+        duration: null,
+        hasError: null,
+        soqlCount: null,
+        dmlCount: null
+      };
+
+      const durA = nodeA.duration ?? 0;
+      const durB = nodeB.duration ?? 0;
+      const delta = durB - durA;
+      const refDuration = Math.max(durA, 1);
+      const percentDelta = Math.abs(delta / refDuration) * 100;
+
+      if (Math.abs(delta) >= config.thresholdMs && percentDelta >= config.thresholdPercent) {
+        changes.duration = { a: durA, b: durB, delta };
+      }
+
+      if (nodeA.hasError !== nodeB.hasError) {
+        changes.hasError = { a: !!nodeA.hasError, b: !!nodeB.hasError };
+      }
+
+      if ((nodeA.soqlCount ?? 0) !== (nodeB.soqlCount ?? 0)) {
+        changes.soqlCount = { a: nodeA.soqlCount ?? 0, b: nodeB.soqlCount ?? 0 };
+      }
+
+      if ((nodeA.dmlCount ?? 0) !== (nodeB.dmlCount ?? 0)) {
+        changes.dmlCount = { a: nodeA.dmlCount ?? 0, b: nodeB.dmlCount ?? 0 };
+      }
+
+      return changes;
+    }
+
+    /**
+     * Filter out system nodes if configured
+     * @param {Array} children
+     * @param {Object} config
+     * @returns {Array}
+     */
+    _filterChildren(children, config) {
+      if (!config.ignoreSystem) return children;
+
+      const systemTypes = new Set([
+        'SYSTEM_METHOD_ENTRY', 'SYSTEM_METHOD_EXIT',
+        'SYSTEM_CONSTRUCTOR_ENTRY', 'SYSTEM_CONSTRUCTOR_EXIT',
+        'VARIABLE_SCOPE_BEGIN', 'VARIABLE_ASSIGNMENT',
+        'STATEMENT_EXECUTE', 'HEAP_ALLOCATE'
+      ]);
+
+      return children.filter(c => !systemTypes.has(c.type));
+    }
+
+    _makeRemovedPair(node) {
+      return {
+        nodeA: this._slimNode(node),
+        nodeB: null,
+        status: 'removed',
+        changes: { duration: null, hasError: null, soqlCount: null, dmlCount: null },
+        children: []
+      };
+    }
+
+    _makeAddedPair(node) {
+      return {
+        nodeA: null,
+        nodeB: this._slimNode(node),
+        status: 'added',
+        changes: { duration: null, hasError: null, soqlCount: null, dmlCount: null },
+        children: []
+      };
+    }
+
+    /**
+     * Keep only essential fields to limit memory usage
+     * @param {Object} node
+     * @returns {Object}
+     */
+    _slimNode(node) {
+      if (!node) return null;
+      return {
+        id: node.id,
+        type: node.type,
+        name: node.name,
+        depth: node.depth,
+        duration: node.duration ?? 0,
+        exclusiveDuration: node.exclusiveDuration ?? 0,
+        hasError: !!node.hasError,
+        soqlCount: node.soqlCount ?? 0,
+        dmlCount: node.dmlCount ?? 0,
+        startTime: node.startTime
+      };
+    }
+
+    /**
+     * Recursively count divergences
+     * @param {Object} pair - Root DiffPair
+     * @returns {Object} Summary counts
+     */
+    _buildSummary(pair) {
+      const summary = {
+        totalDivergences: 0,
+        onlyInA: 0,
+        onlyInB: 0,
+        timingDiffs: 0,
+        errorDiffs: 0
+      };
+
+      this._countDivergences(pair, summary);
+      return summary;
+    }
+
+    _countDivergences(pair, summary) {
+      if (pair.status === 'removed') {
+        summary.totalDivergences++;
+        summary.onlyInA++;
+      } else if (pair.status === 'added') {
+        summary.totalDivergences++;
+        summary.onlyInB++;
+      } else if (pair.status === 'changed') {
+        summary.totalDivergences++;
+        if (pair.changes.duration) summary.timingDiffs++;
+        if (pair.changes.hasError) summary.errorDiffs++;
+      }
+
+      if (pair.children) {
+        for (const child of pair.children) {
+          this._countDivergences(child, summary);
+        }
+      }
+    }
+
+    _emptyResult() {
+      return {
+        summary: { totalDivergences: 0, onlyInA: 0, onlyInB: 0, timingDiffs: 0, errorDiffs: 0 },
+        pairs: { nodeA: null, nodeB: null, status: 'match', changes: {}, children: [] }
+      };
+    }
+  }
+
+  window.FoxLog.logDiffEngine = new LogDiffEngine();
+  window.FoxLog.LogDiffEngine = LogDiffEngine;
+  logger.log('[FoxLog] LogDiffEngine loaded');
+})();

--- a/src/ui/log-diff-view.js
+++ b/src/ui/log-diff-view.js
@@ -1,0 +1,316 @@
+// src/ui/log-diff-view.js
+// Split-pane diff view for comparing two CallTrees side by side
+
+(function() {
+  'use strict';
+
+  window.FoxLog = window.FoxLog || {};
+  const i18n = window.FoxLog.i18n || {};
+  const logger = window.FoxLog.logger || console;
+  const escapeHtml = window.FoxLog.escapeHtml || (s => s);
+
+  class LogDiffView {
+    /**
+     * @param {HTMLElement} container - DOM container
+     * @param {Object} diffResult - Result from LogDiffEngine.diff()
+     * @param {Object} metaA - { filename, operation, duration }
+     * @param {Object} metaB - { filename, operation, duration }
+     */
+    constructor(container, diffResult, metaA, metaB) {
+      this.container = container;
+      this.diffResult = diffResult;
+      this.metaA = metaA || {};
+      this.metaB = metaB || {};
+
+      this.flatPairs = [];
+      this.divergenceIndices = [];
+      this.currentDivergenceIdx = -1;
+
+      this.nodeHeight = 32;
+      this.scrollTop = 0;
+      this.renderBuffer = 10;
+
+      this.scrollContainerA = null;
+      this.scrollContainerB = null;
+      this._isSyncing = false;
+    }
+
+    render() {
+      this._flatten(this.diffResult.pairs, 0);
+      this._buildDivergenceIndex();
+      this.container.innerHTML = '';
+      this.container.appendChild(this._buildDOM());
+
+      requestAnimationFrame(() => {
+        this.scrollContainerA = this.container.querySelector('.sf-diff-scroll-a');
+        this.scrollContainerB = this.container.querySelector('.sf-diff-scroll-b');
+        this._setupSyncScroll();
+        this._setupNavButtons();
+        this._renderRows();
+      });
+    }
+
+    destroy() {
+      this.container.innerHTML = '';
+      this.flatPairs = [];
+      this.divergenceIndices = [];
+      this.diffResult = null;
+    }
+
+    /** Flatten the recursive DiffPair tree into a flat list with depth */
+    _flatten(pair, depth) {
+      this.flatPairs.push({ pair, depth });
+      if (pair.children) {
+        for (const child of pair.children) {
+          this._flatten(child, depth + 1);
+        }
+      }
+    }
+
+    _buildDivergenceIndex() {
+      this.flatPairs.forEach((item, idx) => {
+        if (item.pair.status !== 'match') {
+          this.divergenceIndices.push(idx);
+        }
+      });
+    }
+
+    _buildDOM() {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'sf-diff-wrapper';
+
+      const summary = this.diffResult.summary;
+      wrapper.innerHTML = `
+        <div class="sf-diff-header">
+          <div class="sf-diff-meta sf-diff-meta-a">
+            <span class="sf-diff-label">A</span>
+            <span class="sf-diff-filename" title="${escapeHtml(this.metaA.filename || '')}">${escapeHtml(this.metaA.filename || 'Log A')}</span>
+          </div>
+          <div class="sf-diff-meta sf-diff-meta-b">
+            <span class="sf-diff-label">B</span>
+            <span class="sf-diff-filename" title="${escapeHtml(this.metaB.filename || '')}">${escapeHtml(this.metaB.filename || 'Log B')}</span>
+          </div>
+        </div>
+        <div class="sf-diff-summary-bar">
+          <span class="sf-diff-stat sf-diff-stat-total">${summary.totalDivergences} ${i18n.diffDivergences || 'divergences'}</span>
+          ${summary.onlyInA ? `<span class="sf-diff-stat sf-diff-stat-removed">−${summary.onlyInA}</span>` : ''}
+          ${summary.onlyInB ? `<span class="sf-diff-stat sf-diff-stat-added">+${summary.onlyInB}</span>` : ''}
+          ${summary.timingDiffs ? `<span class="sf-diff-stat sf-diff-stat-timing">⏱ ${summary.timingDiffs}</span>` : ''}
+          ${summary.errorDiffs ? `<span class="sf-diff-stat sf-diff-stat-error">❌ ${summary.errorDiffs}</span>` : ''}
+        </div>
+        <div class="sf-diff-panes">
+          <div class="sf-diff-pane sf-diff-pane-a">
+            <div class="sf-diff-scroll-a" role="region" aria-label="Log A tree"></div>
+          </div>
+          <div class="sf-diff-gutter"></div>
+          <div class="sf-diff-pane sf-diff-pane-b">
+            <div class="sf-diff-scroll-b" role="region" aria-label="Log B tree"></div>
+          </div>
+        </div>
+        <div class="sf-diff-nav-bar">
+          <button class="sf-diff-nav-btn sf-diff-prev" aria-label="${i18n.diffPrev || 'Previous difference'}">◄ ${i18n.diffPrev || 'Prev'}</button>
+          <span class="sf-diff-nav-position">
+            ${summary.totalDivergences === 0
+              ? (i18n.diffNoDivergences || 'No divergences')
+              : `<span class="sf-diff-nav-current">0</span> / ${summary.totalDivergences}`
+            }
+          </span>
+          <button class="sf-diff-nav-btn sf-diff-next" aria-label="${i18n.diffNext || 'Next difference'}">${i18n.diffNext || 'Next'} ►</button>
+        </div>
+      `;
+
+      return wrapper;
+    }
+
+    _renderRows() {
+      const paneA = this.scrollContainerA;
+      const paneB = this.scrollContainerB;
+      if (!paneA || !paneB) return;
+
+      const fragmentA = document.createDocumentFragment();
+      const fragmentB = document.createDocumentFragment();
+
+      for (let i = 0; i < this.flatPairs.length; i++) {
+        const { pair, depth } = this.flatPairs[i];
+        const rowA = this._createRow(pair, 'a', depth, i);
+        const rowB = this._createRow(pair, 'b', depth, i);
+        fragmentA.appendChild(rowA);
+        fragmentB.appendChild(rowB);
+      }
+
+      paneA.innerHTML = '';
+      paneB.innerHTML = '';
+      paneA.appendChild(fragmentA);
+      paneB.appendChild(fragmentB);
+    }
+
+    /**
+     * Create a single row element for one side of the diff
+     * @param {Object} pair - DiffPair
+     * @param {'a'|'b'} side
+     * @param {number} depth
+     * @param {number} rowIndex
+     * @returns {HTMLElement}
+     */
+    _createRow(pair, side, depth, rowIndex) {
+      const row = document.createElement('div');
+      row.className = `sf-diff-row sf-diff-row-${pair.status}`;
+      row.dataset.index = rowIndex;
+      row.style.paddingLeft = `${depth * 16 + 8}px`;
+
+      const node = side === 'a' ? pair.nodeA : pair.nodeB;
+      const isEmpty = !node;
+
+      if (isEmpty) {
+        row.classList.add('sf-diff-row-empty');
+        row.innerHTML = `<span class="sf-diff-empty-placeholder">&nbsp;</span>`;
+        return row;
+      }
+
+      const icon = this._getNodeIcon(node.type);
+      const name = escapeHtml(node.name || node.type || '');
+      const durationStr = this._formatDuration(node.duration);
+
+      let badge = '';
+      if (pair.status === 'added') {
+        badge = '<span class="sf-diff-badge sf-diff-badge-added" aria-label="Added">+</span>';
+      } else if (pair.status === 'removed') {
+        badge = '<span class="sf-diff-badge sf-diff-badge-removed" aria-label="Removed">−</span>';
+      } else if (pair.status === 'changed' && pair.changes.duration && side === 'b') {
+        const delta = pair.changes.duration.delta;
+        const sign = delta > 0 ? '+' : '';
+        const pct = pair.changes.duration.a > 0
+          ? Math.round((delta / pair.changes.duration.a) * 100)
+          : 0;
+        badge = `<span class="sf-diff-badge sf-diff-badge-timing" aria-label="Duration change: ${sign}${pct}%">${sign}${pct}%</span>`;
+      }
+
+      let errorIcon = '';
+      if (pair.status === 'changed' && pair.changes.hasError) {
+        if ((side === 'a' && pair.changes.hasError.a) || (side === 'b' && pair.changes.hasError.b)) {
+          errorIcon = ' <span class="sf-diff-error-icon" aria-label="Error">❌</span>';
+        }
+      } else if (node.hasError) {
+        errorIcon = ' <span class="sf-diff-error-icon" aria-label="Error">❌</span>';
+      }
+
+      row.innerHTML = `
+        <span class="sf-diff-node-icon">${icon}</span>
+        <span class="sf-diff-node-name" title="${name}">${name}</span>
+        <span class="sf-diff-node-duration">${durationStr}</span>
+        ${badge}${errorIcon}
+      `;
+
+      const ariaDesc = this._getAriaDescription(pair, side, node);
+      row.setAttribute('aria-label', ariaDesc);
+
+      return row;
+    }
+
+    _getNodeIcon(type) {
+      const icons = {
+        'METHOD_ENTRY': '⚙️',
+        'SOQL_EXECUTE_BEGIN': '🔍',
+        'DML_BEGIN': '💾',
+        'EXCEPTION_THROWN': '❌',
+        'USER_DEBUG': '🐛',
+        'CODE_UNIT_STARTED': '📦',
+        'FLOW_START_INTERVIEW_BEGIN': '🔀',
+        'VALIDATION_RULE': '✅',
+        'ROOT': '🌳'
+      };
+      return icons[type] || '▸';
+    }
+
+    _formatDuration(ms) {
+      if (ms == null || ms === 0) return '';
+      if (ms < 1) return '<1ms';
+      if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+      return `${Math.round(ms)}ms`;
+    }
+
+    _getAriaDescription(pair, side, node) {
+      const name = node.name || node.type;
+      const dur = this._formatDuration(node.duration);
+      if (pair.status === 'added') return `${i18n.diffAdded || 'Added'}: ${name}, ${dur}`;
+      if (pair.status === 'removed') return `${i18n.diffRemoved || 'Removed'}: ${name}, ${dur}`;
+      if (pair.status === 'changed') return `${i18n.diffChanged || 'Changed'}: ${name}, ${dur}`;
+      return `${name}, ${dur}`;
+    }
+
+    _setupSyncScroll() {
+      if (!this.scrollContainerA || !this.scrollContainerB) return;
+
+      const paneA = this.scrollContainerA.parentElement;
+      const paneB = this.scrollContainerB.parentElement;
+
+      const sync = (source, target) => {
+        if (this._isSyncing) return;
+        this._isSyncing = true;
+        target.scrollTop = source.scrollTop;
+        this._isSyncing = false;
+      };
+
+      paneA.addEventListener('scroll', () => sync(paneA, paneB));
+      paneB.addEventListener('scroll', () => sync(paneB, paneA));
+    }
+
+    _setupNavButtons() {
+      const prevBtn = this.container.querySelector('.sf-diff-prev');
+      const nextBtn = this.container.querySelector('.sf-diff-next');
+
+      if (prevBtn) prevBtn.addEventListener('click', () => this.navigatePrev());
+      if (nextBtn) nextBtn.addEventListener('click', () => this.navigateNext());
+    }
+
+    navigateNext() {
+      if (this.divergenceIndices.length === 0) return;
+      this.currentDivergenceIdx = Math.min(this.currentDivergenceIdx + 1, this.divergenceIndices.length - 1);
+      this._scrollToDivergence();
+    }
+
+    navigatePrev() {
+      if (this.divergenceIndices.length === 0) return;
+      this.currentDivergenceIdx = Math.max(this.currentDivergenceIdx - 1, 0);
+      this._scrollToDivergence();
+    }
+
+    _scrollToDivergence() {
+      const rowIndex = this.divergenceIndices[this.currentDivergenceIdx];
+      if (rowIndex == null) return;
+
+      this._updateNavPosition();
+      this._highlightRow(rowIndex);
+
+      const offset = rowIndex * this.nodeHeight;
+      const paneA = this.scrollContainerA?.parentElement;
+      if (paneA) {
+        paneA.scrollTop = Math.max(0, offset - paneA.clientHeight / 2);
+      }
+    }
+
+    _updateNavPosition() {
+      const posEl = this.container.querySelector('.sf-diff-nav-current');
+      if (posEl) {
+        posEl.textContent = this.currentDivergenceIdx + 1;
+      }
+    }
+
+    _highlightRow(rowIndex) {
+      // Remove previous highlights
+      this.container.querySelectorAll('.sf-diff-row-highlight').forEach(el => {
+        el.classList.remove('sf-diff-row-highlight');
+      });
+
+      const rows = this.container.querySelectorAll(`[data-index="${rowIndex}"]`);
+      rows.forEach(r => r.classList.add('sf-diff-row-highlight'));
+
+      setTimeout(() => {
+        rows.forEach(r => r.classList.remove('sf-diff-row-highlight'));
+      }, 2000);
+    }
+  }
+
+  window.FoxLog.LogDiffView = LogDiffView;
+  logger.log('[FoxLog] LogDiffView loaded');
+})();

--- a/src/ui/modal-manager.js
+++ b/src/ui/modal-manager.js
@@ -156,6 +156,7 @@
             </button>
             <button class="sf-tab-btn" data-tab="calls">${i18n.calls || 'Calls'}</button>
             <button class="sf-tab-btn" data-tab="raw">${i18n.rawLog || 'Raw Log'}</button>
+            <button class="sf-tab-btn" data-tab="diff">${i18n.diffTab || 'Diff'}</button>
           </div>
           
           <div class="sf-modal-body-tabs">
@@ -177,6 +178,22 @@
             <div id="tab-raw" class="sf-tab-content">
               ${this._renderRawTab(parsedLog)}
             </div>
+
+            <div id="tab-diff" class="sf-tab-content">
+              <div class="sf-diff-select-container">
+                <div class="sf-diff-top-bar">
+                  <select class="sf-diff-log-select" aria-label="${i18n.diffSelectLog || 'Select an imported log to compare'}">
+                    <option value="">-- ${i18n.diffSelectLog || 'Select an imported log'} --</option>
+                  </select>
+                  <span class="sf-diff-or">${i18n.diffOr || 'or'}</span>
+                  <label class="sf-diff-import-btn" tabindex="0" role="button" aria-label="${i18n.diffImportFile || 'Import a file'}">
+                    📂 ${i18n.diffImportFile || 'Import a file'}
+                    <input type="file" class="sf-diff-file-input" accept=".txt,.log" hidden />
+                  </label>
+                </div>
+                <div class="sf-diff-content-area"></div>
+              </div>
+            </div>
           </div>
         </div>
       `;
@@ -184,6 +201,7 @@
       this._attachModal(modal);
       this._setupTabs(modal);
       this._setupCallsTab(modal, parsedLog);
+      this._setupDiffTab(modal, parsedLog);
 
       this._setupExportButtons(modal, parsedLog);
       
@@ -261,6 +279,27 @@
       const rawTab = modal.querySelector('#tab-raw');
       if (rawTab) {
         rawTab.innerHTML = this._renderRawTab(parsedLog);
+      }
+      
+      // Reset Diff tab
+      const diffTab = modal.querySelector('#tab-diff');
+      if (diffTab) {
+        diffTab.innerHTML = `
+          <div class="sf-diff-select-container">
+            <div class="sf-diff-top-bar">
+              <select class="sf-diff-log-select" aria-label="${i18n.diffSelectLog || 'Select an imported log to compare'}">
+                <option value="">-- ${i18n.diffSelectLog || 'Select an imported log'} --</option>
+              </select>
+              <span class="sf-diff-or">${i18n.diffOr || 'or'}</span>
+              <label class="sf-diff-import-btn" tabindex="0" role="button" aria-label="${i18n.diffImportFile || 'Import a file'}">
+                📂 ${i18n.diffImportFile || 'Import a file'}
+                <input type="file" class="sf-diff-file-input" accept=".txt,.log" hidden />
+              </label>
+            </div>
+            <div class="sf-diff-content-area"></div>
+          </div>
+        `;
+        this._setupDiffTab(modal, parsedLog);
       }
       
       // Re-setup export buttons
@@ -1395,6 +1434,255 @@
             </div>
           `;
         }
+      });
+    }
+
+    /**
+     * Configure le lazy-loading de l'onglet Diff
+     * @private
+     */
+    async _setupDiffTab(modal, parsedLogA) {
+      const { callTreeBuilder, LogDiffView } = window.FoxLog;
+
+      const diffBtn = modal.querySelector('[data-tab="diff"]');
+      if (!diffBtn) return;
+
+      let diffInitialized = false;
+
+      diffBtn.addEventListener('click', async () => {
+        if (diffInitialized) return;
+        diffInitialized = true;
+        await this._populateDiffImportSelect(modal, parsedLogA);
+      });
+    }
+
+    /**
+     * Load imported logs list into the Diff tab dropdown
+     * @private
+     */
+    async _populateDiffImportSelect(modal, parsedLogA) {
+      const select = modal.querySelector('.sf-diff-log-select');
+      const fileInput = modal.querySelector('.sf-diff-file-input');
+
+      // Wire inline file import
+      if (fileInput) {
+        fileInput.addEventListener('change', async (e) => {
+          const file = e.target.files?.[0];
+          if (!file) return;
+          await this._handleDiffImport(modal, parsedLogA, file);
+          fileInput.value = '';
+        });
+      }
+
+      if (!select) return;
+
+      try {
+        const result = await new Promise(resolve => {
+          chrome.storage.local.get('importedLogs', resolve);
+        });
+
+        const imports = result.importedLogs || [];
+
+        imports.forEach(imp => {
+          const option = document.createElement('option');
+          option.value = imp.id;
+          const date = new Date(imp.date).toLocaleString();
+          option.textContent = `${imp.filename} (${date})`;
+          select.appendChild(option);
+        });
+
+        select.addEventListener('change', async () => {
+          const importId = select.value;
+          if (!importId) return;
+          await this._runDiff(modal, parsedLogA, importId);
+        });
+      } catch (error) {
+        logger.error('Failed to load imported logs for diff', error);
+      }
+    }
+
+    /**
+     * Import a file directly from the Diff tab, save to storage, then run diff
+     * @private
+     */
+    async _handleDiffImport(modal, parsedLogA, file) {
+      const MAX_FILE_SIZE = 5 * 1024 * 1024;
+      const validExtensions = ['.txt', '.log'];
+      const ext = '.' + file.name.split('.').pop().toLowerCase();
+
+      if (!validExtensions.includes(ext)) {
+        this._showToast(i18n.importInvalidType || 'Invalid file type. Use .txt or .log', 'error');
+        return;
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        this._showToast(i18n.importFileTooLarge || 'File too large (max 5 MB)', 'error');
+        return;
+      }
+
+      const content = await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = (e) => resolve(e.target.result);
+        reader.onerror = () => reject(new Error('Failed to read file'));
+        reader.readAsText(file);
+      });
+
+      const importEntry = {
+        id: 'imp_' + Date.now(),
+        filename: file.name,
+        date: new Date().toISOString(),
+        size: file.size,
+        content
+      };
+
+      // Save to storage (same logic as panel-manager)
+      await new Promise(resolve => {
+        chrome.storage.local.get(['importedLogs'], (result) => {
+          const imports = result.importedLogs || [];
+          const MAX_STORAGE = 10 * 1024 * 1024;
+          imports.unshift(importEntry);
+
+          let totalSize = imports.reduce((sum, imp) => sum + (imp.size || 0), 0);
+          while (totalSize > MAX_STORAGE && imports.length > 1) {
+            const removed = imports.pop();
+            totalSize -= (removed.size || 0);
+          }
+
+          chrome.storage.local.set({ importedLogs: imports }, resolve);
+        });
+      });
+
+      // Refresh the Files panel if open
+      document.dispatchEvent(new CustomEvent('foxlog:importListChanged'));
+
+      // Add option to dropdown and select it
+      const select = modal.querySelector('.sf-diff-log-select');
+      if (select) {
+        const option = document.createElement('option');
+        option.value = importEntry.id;
+        const date = new Date(importEntry.date).toLocaleString();
+        option.textContent = `${importEntry.filename} (${date})`;
+        select.insertBefore(option, select.options[1]);
+        select.value = importEntry.id;
+      }
+
+      logger.success(`File imported from Diff tab: ${file.name}`);
+
+      // Run diff immediately
+      await this._runDiff(modal, parsedLogA, importEntry.id);
+    }
+
+    /**
+     * Execute diff between current log and selected imported log
+     * @private
+     */
+    async _runDiff(modal, parsedLogA, importId) {
+      const { callTreeBuilder, LogDiffView, logParser } = window.FoxLog;
+      const contentArea = modal.querySelector('.sf-diff-content-area');
+      if (!contentArea) return;
+
+      contentArea.innerHTML = `
+        <div class="sf-calls-loading">
+          <div class="sf-spinner"></div>
+          <div class="sf-loading-text">${i18n.diffComputing || 'Computing diff...'}</div>
+        </div>
+      `;
+
+      try {
+        const result = await new Promise(resolve => {
+          chrome.storage.local.get('importedLogs', resolve);
+        });
+        const imports = result.importedLogs || [];
+        const importData = imports.find(imp => imp.id === importId);
+
+        if (!importData || !importData.content) {
+          throw new Error('Imported log content not found');
+        }
+
+        const parsedLogB = logParser.parse(importData.content, {
+          id: importData.id,
+          filename: importData.filename
+        });
+
+        if (!callTreeBuilder) {
+          throw new Error('CallTreeBuilder not available');
+        }
+
+        const [treeA, treeB] = await Promise.all([
+          callTreeBuilder.buildTree(parsedLogA),
+          callTreeBuilder.buildTree(parsedLogB)
+        ]);
+
+        const diffResult = await this._runDiffWorker(treeA, treeB);
+
+        contentArea.innerHTML = '<div class="sf-diff-view-container"></div>';
+        const container = contentArea.querySelector('.sf-diff-view-container');
+
+        const metaA = {
+          filename: parsedLogA.metadata?.operation || 'Log A'
+        };
+        const metaB = {
+          filename: importData.filename || 'Log B'
+        };
+
+        const diffView = new LogDiffView(container, diffResult, metaA, metaB);
+        diffView.render();
+
+        logger.success('Diff view rendered');
+      } catch (error) {
+        logger.error('Diff computation failed', error);
+        contentArea.innerHTML = `
+          <div class="sf-empty-state">
+            <p style="color: #ef4444; font-weight: 600;">⚠️ ${i18n.error || 'Error'}</p>
+            <p style="color: #666;">${i18n.diffError || 'Diff computation error'}</p>
+            <p class="sf-hint">${error.message}</p>
+          </div>
+        `;
+      }
+    }
+
+    /**
+     * Run diff in a Web Worker with timeout
+     * @private
+     */
+    async _runDiffWorker(treeA, treeB) {
+      const timeout = window.FoxLog.CONFIG?.DIFF_WORKER_TIMEOUT ?? 10000;
+
+      // Fetch worker code and create Blob URL (same pattern as call-tree-builder)
+      const workerUrl = chrome.runtime.getURL('src/workers/log-diff-worker.js');
+      const response = await fetch(workerUrl);
+      const workerCode = await response.text();
+      const blob = new Blob([workerCode], { type: 'application/javascript' });
+      const blobUrl = URL.createObjectURL(blob);
+
+      return new Promise((resolve, reject) => {
+        const worker = new Worker(blobUrl);
+        const requestId = Date.now().toString();
+
+        const timer = setTimeout(() => {
+          worker.terminate();
+          URL.revokeObjectURL(blobUrl);
+          reject(new Error(i18n.diffTimeout || 'Diff computation timed out'));
+        }, timeout);
+
+        worker.onmessage = (event) => {
+          clearTimeout(timer);
+          worker.terminate();
+          URL.revokeObjectURL(blobUrl);
+          if (event.data.type === 'error') {
+            reject(new Error(event.data.error));
+          } else {
+            resolve(event.data.result);
+          }
+        };
+
+        worker.onerror = (error) => {
+          clearTimeout(timer);
+          worker.terminate();
+          URL.revokeObjectURL(blobUrl);
+          reject(error);
+        };
+
+        worker.postMessage({ type: 'diff', treeA, treeB, requestId });
       });
     }
 

--- a/src/ui/panel-manager.js
+++ b/src/ui/panel-manager.js
@@ -133,6 +133,7 @@
           this.selectedUserId = users[0].id;
           userSelect.value = users[0].id;
         } else {
+          userSelect.value = currentUserId;
           this.selectedUserId = currentUserId;
         }
 
@@ -655,6 +656,11 @@
       
       // Load import history on startup
       this._loadImportHistory();
+
+      // Refresh import list when a file is imported from the Diff tab
+      document.addEventListener('foxlog:importListChanged', () => {
+        this._loadImportHistory();
+      });
     }
 
     _showEmptyState() {

--- a/src/workers/log-diff-worker.js
+++ b/src/workers/log-diff-worker.js
@@ -1,0 +1,221 @@
+// src/workers/log-diff-worker.js
+// Web Worker that computes diff between two CallTrees off the main thread
+
+'use strict';
+
+const DEBUG_MODE = false;
+
+const logger = {
+  _isEnabled() { return DEBUG_MODE; },
+  log: (msg) => { if (logger._isEnabled()) console.log(`[FoxLog DiffWorker] ${msg}`); },
+  error: (msg, err) => { console.error(`[FoxLog DiffWorker] ❌ ${msg}`, err || ''); }
+};
+
+// ============================================
+// DIFF ENGINE (duplicated for Worker isolation)
+// ============================================
+
+class LogDiffEngine {
+  diff(treeA, treeB, options = {}) {
+    const config = {
+      thresholdMs: options.thresholdMs ?? 50,
+      thresholdPercent: options.thresholdPercent ?? 200,
+      ignoreSystem: options.ignoreSystem ?? true
+    };
+
+    const rootA = treeA?.root;
+    const rootB = treeB?.root;
+
+    if (!rootA || !rootB) {
+      return this._emptyResult();
+    }
+
+    const rootPair = this._diffNode(rootA, rootB, config);
+    const summary = this._buildSummary(rootPair);
+
+    return { summary, pairs: rootPair };
+  }
+
+  _diffNode(nodeA, nodeB, config) {
+    const changes = this._detectChanges(nodeA, nodeB, config);
+    const hasChanges = changes.duration || changes.hasError || changes.soqlCount || changes.dmlCount;
+    const status = hasChanges ? 'changed' : 'match';
+
+    const childrenA = this._filterChildren(nodeA.children || [], config);
+    const childrenB = this._filterChildren(nodeB.children || [], config);
+    const childPairs = this._alignChildren(childrenA, childrenB, config);
+
+    return {
+      nodeA: this._slimNode(nodeA),
+      nodeB: this._slimNode(nodeB),
+      status,
+      changes,
+      children: childPairs
+    };
+  }
+
+  _alignChildren(childrenA, childrenB, config) {
+    const sigsA = childrenA.map(n => this._getSignature(n));
+    const sigsB = childrenB.map(n => this._getSignature(n));
+    const lcs = this._computeLCS(sigsA, sigsB);
+
+    const pairs = [];
+    let idxA = 0;
+    let idxB = 0;
+
+    for (const match of lcs) {
+      while (idxA < match.idxA) { pairs.push(this._makeRemovedPair(childrenA[idxA])); idxA++; }
+      while (idxB < match.idxB) { pairs.push(this._makeAddedPair(childrenB[idxB])); idxB++; }
+      pairs.push(this._diffNode(childrenA[idxA], childrenB[idxB], config));
+      idxA++;
+      idxB++;
+    }
+
+    while (idxA < childrenA.length) { pairs.push(this._makeRemovedPair(childrenA[idxA])); idxA++; }
+    while (idxB < childrenB.length) { pairs.push(this._makeAddedPair(childrenB[idxB])); idxB++; }
+
+    return pairs;
+  }
+
+  _computeLCS(seqA, seqB) {
+    const m = seqA.length;
+    const n = seqB.length;
+    const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+
+    for (let i = 1; i <= m; i++) {
+      for (let j = 1; j <= n; j++) {
+        if (seqA[i - 1] === seqB[j - 1]) {
+          dp[i][j] = dp[i - 1][j - 1] + 1;
+        } else {
+          dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+        }
+      }
+    }
+
+    const result = [];
+    let i = m;
+    let j = n;
+    while (i > 0 && j > 0) {
+      if (seqA[i - 1] === seqB[j - 1]) {
+        result.push({ idxA: i - 1, idxB: j - 1 });
+        i--; j--;
+      } else if (dp[i - 1][j] > dp[i][j - 1]) {
+        i--;
+      } else {
+        j--;
+      }
+    }
+    result.reverse();
+    return result;
+  }
+
+  _getSignature(node) {
+    return `${node.type || 'UNKNOWN'}:${node.name || ''}`;
+  }
+
+  _detectChanges(nodeA, nodeB, config) {
+    const changes = { duration: null, hasError: null, soqlCount: null, dmlCount: null };
+
+    const durA = nodeA.duration ?? 0;
+    const durB = nodeB.duration ?? 0;
+    const delta = durB - durA;
+    const refDuration = Math.max(durA, 1);
+    const percentDelta = Math.abs(delta / refDuration) * 100;
+
+    if (Math.abs(delta) >= config.thresholdMs && percentDelta >= config.thresholdPercent) {
+      changes.duration = { a: durA, b: durB, delta };
+    }
+    if (nodeA.hasError !== nodeB.hasError) {
+      changes.hasError = { a: !!nodeA.hasError, b: !!nodeB.hasError };
+    }
+    if ((nodeA.soqlCount ?? 0) !== (nodeB.soqlCount ?? 0)) {
+      changes.soqlCount = { a: nodeA.soqlCount ?? 0, b: nodeB.soqlCount ?? 0 };
+    }
+    if ((nodeA.dmlCount ?? 0) !== (nodeB.dmlCount ?? 0)) {
+      changes.dmlCount = { a: nodeA.dmlCount ?? 0, b: nodeB.dmlCount ?? 0 };
+    }
+    return changes;
+  }
+
+  _filterChildren(children, config) {
+    if (!config.ignoreSystem) return children;
+    const systemTypes = new Set([
+      'SYSTEM_METHOD_ENTRY', 'SYSTEM_METHOD_EXIT',
+      'SYSTEM_CONSTRUCTOR_ENTRY', 'SYSTEM_CONSTRUCTOR_EXIT',
+      'VARIABLE_SCOPE_BEGIN', 'VARIABLE_ASSIGNMENT',
+      'STATEMENT_EXECUTE', 'HEAP_ALLOCATE'
+    ]);
+    return children.filter(c => !systemTypes.has(c.type));
+  }
+
+  _makeRemovedPair(node) {
+    return { nodeA: this._slimNode(node), nodeB: null, status: 'removed', changes: { duration: null, hasError: null, soqlCount: null, dmlCount: null }, children: [] };
+  }
+
+  _makeAddedPair(node) {
+    return { nodeA: null, nodeB: this._slimNode(node), status: 'added', changes: { duration: null, hasError: null, soqlCount: null, dmlCount: null }, children: [] };
+  }
+
+  _slimNode(node) {
+    if (!node) return null;
+    return {
+      id: node.id, type: node.type, name: node.name, depth: node.depth,
+      duration: node.duration ?? 0, exclusiveDuration: node.exclusiveDuration ?? 0,
+      hasError: !!node.hasError, soqlCount: node.soqlCount ?? 0, dmlCount: node.dmlCount ?? 0,
+      startTime: node.startTime
+    };
+  }
+
+  _buildSummary(pair) {
+    const summary = { totalDivergences: 0, onlyInA: 0, onlyInB: 0, timingDiffs: 0, errorDiffs: 0 };
+    this._countDivergences(pair, summary);
+    return summary;
+  }
+
+  _countDivergences(pair, summary) {
+    if (pair.status === 'removed') { summary.totalDivergences++; summary.onlyInA++; }
+    else if (pair.status === 'added') { summary.totalDivergences++; summary.onlyInB++; }
+    else if (pair.status === 'changed') {
+      summary.totalDivergences++;
+      if (pair.changes.duration) summary.timingDiffs++;
+      if (pair.changes.hasError) summary.errorDiffs++;
+    }
+    if (pair.children) {
+      for (const child of pair.children) { this._countDivergences(child, summary); }
+    }
+  }
+
+  _emptyResult() {
+    return {
+      summary: { totalDivergences: 0, onlyInA: 0, onlyInB: 0, timingDiffs: 0, errorDiffs: 0 },
+      pairs: { nodeA: null, nodeB: null, status: 'match', changes: {}, children: [] }
+    };
+  }
+}
+
+// ============================================
+// MESSAGE HANDLER
+// ============================================
+
+const engine = new LogDiffEngine();
+
+self.onmessage = function(event) {
+  const { type, treeA, treeB, options, requestId } = event.data;
+
+  if (type === 'diff') {
+    try {
+      logger.log('Starting diff computation...');
+      const startTime = performance.now();
+
+      const result = engine.diff(treeA, treeB, options);
+
+      const duration = performance.now() - startTime;
+      logger.log(`Diff computed in ${duration.toFixed(2)}ms`);
+
+      self.postMessage({ type: 'result', result, duration, requestId });
+    } catch (error) {
+      logger.error('Diff computation failed', error);
+      self.postMessage({ type: 'error', error: error.message, requestId });
+    }
+  }
+};


### PR DESCRIPTION
- Implemented LogDiffEngine to compute differences between two CallTree structures.
- Created LogDiffView for a split-pane UI to visualize the differences side by side.
- Added log-diff-worker to handle diff computations off the main thread for improved performance.
- Introduced methods for detecting changes, aligning children, and summarizing divergences.
- Enhanced UI with navigation buttons and synchronized scrolling for better user experience.